### PR TITLE
Update app.txt.py

### DIFF
--- a/app.txt.py
+++ b/app.txt.py
@@ -2,42 +2,43 @@ import tkinter as tk
 from tkinter import font
 import random
 import json
+import threading
 import urllib.request
-import base64
+from PIL import Image, ImageTk
+import io
+
 
 class RockPaperScissorsGUI:
     """
-    A GUI for the strategic 'Rock-Paper-Scissors Subtract One' game with API integration.
-
-    Game Rules:
-    1. Player chooses two hands.
-    2. Computer chooses two hands, which are then revealed to the player.
-    3. Player sees the computer's hands and strategically decides which of their own to keep.
-    4. The computer uses an AI to predict the player's move and chooses its own hand to counter.
-    5. On winning, a wild Pokemon appears to celebrate!
+    A GUI for the strategic 'Rock-Paper-Scissors Subtract One' game with async API integration
+    and improved image quality via Pillow.
     """
+
     def __init__(self, master):
         self.master = master
         self.master.title("가위바위보 - 하나빼기 (API 버전)")
         self.master.geometry("500x550")
         self.master.resizable(False, False)
 
-        # Game options and state variables
+        # Game options and states
         self.options = {"바위": "rock", "보": "paper", "가위": "scissors"}
         self.player_choices = []
         self.computer_choices = []
         self.player_score = 0
         self.computer_score = 0
-        self.pokemon_image = None # To prevent garbage collection
+        self.pokemon_image = None  
 
-        # Setup fonts
+        # Critical Hit
+        self.critical_chance = 0.10
+
+        # Fonts
         self.default_font = font.Font(family="Malgun Gothic", size=12)
         self.info_font = font.Font(family="Malgun Gothic", size=14, weight="bold")
         self.status_font = font.Font(family="Malgun Gothic", size=14, slant="italic")
         self.result_font = font.Font(family="Malgun Gothic", size=16, weight="bold")
         self.label_font = font.Font(family="Malgun Gothic", size=11)
 
-        # --- UI Widgets ---
+        # UI ========================================================
         self.info_label = tk.Label(master, text="첫 번째 손을 선택하세요", font=self.info_font, pady=10)
         self.info_label.pack()
 
@@ -52,35 +53,47 @@ class RockPaperScissorsGUI:
             )
             self.buttons[text].pack(side=tk.LEFT, padx=5)
 
-        # --- Strategic Choice Section ---
         self.strategy_frame = tk.Frame(master, pady=10)
         self.strategy_frame.pack()
 
-        # Player's side
+        # Player strategic choice
         self.player_strategy_frame = tk.Frame(self.strategy_frame, padx=10)
         self.player_strategy_frame.pack(side=tk.LEFT, anchor='n')
         tk.Label(self.player_strategy_frame, text="[나의 패]", font=self.label_font).pack()
+
         self.player_selection_frame = tk.Frame(self.player_strategy_frame, pady=10)
         self.player_selection_frame.pack()
+
         self.final_choice_buttons = []
 
-        # Computer's side
+        # Computer strategic choice
         self.computer_strategy_frame = tk.Frame(self.strategy_frame, padx=10)
         self.computer_strategy_frame.pack(side=tk.RIGHT, anchor='n')
+
         tk.Label(self.computer_strategy_frame, text="[컴퓨터의 패]", font=self.label_font).pack()
+
         self.computer_selection_frame = tk.Frame(self.computer_strategy_frame, pady=10)
         self.computer_selection_frame.pack()
-        self.computer_hand1_label = tk.Label(self.computer_selection_frame, text="?", font=self.default_font, width=8, relief="solid", borderwidth=1, height=2)
-        self.computer_hand2_label = tk.Label(self.computer_selection_frame, text="?", font=self.default_font, width=8, relief="solid", borderwidth=1, height=2)
+
+        self.computer_hand1_label = tk.Label(
+            self.computer_selection_frame, text="?", font=self.default_font,
+            width=8, relief="solid", borderwidth=1, height=2
+        )
+        self.computer_hand2_label = tk.Label(
+            self.computer_selection_frame, text="?", font=self.default_font,
+            width=8, relief="solid", borderwidth=1, height=2
+        )
         self.computer_hand1_label.pack(side=tk.LEFT, padx=5)
         self.computer_hand2_label.pack(side=tk.LEFT, padx=5)
-        
-        # --- Result Section ---
+
+        # Result section
         self.result_display_frame = tk.Frame(master, pady=15)
         self.result_display_frame.pack()
+
         self.player_final_label = tk.Label(self.result_display_frame, text="", font=self.result_font, width=8)
         self.vs_label = tk.Label(self.result_display_frame, text="", font=self.default_font)
         self.computer_final_label = tk.Label(self.result_display_frame, text="", font=self.result_font, width=8)
+
         self.player_final_label.pack(side=tk.LEFT)
         self.vs_label.pack(side=tk.LEFT, padx=10)
         self.computer_final_label.pack(side=tk.LEFT)
@@ -91,16 +104,24 @@ class RockPaperScissorsGUI:
         self.score_label = tk.Label(master, text=self.get_score_text(), font=self.default_font)
         self.score_label.pack()
 
-        self.play_again_button = tk.Button(master, text="다시하기", font=self.default_font, state=tk.DISABLED, command=self.reset_game)
+        self.play_again_button = tk.Button(
+            master, text="다시하기", font=self.default_font, state=tk.DISABLED,
+            command=self.reset_game
+        )
         self.play_again_button.pack(pady=15)
+
+    # ==============================================================
 
     def get_score_text(self):
         return f"점수: 플레이어 {self.player_score} - {self.computer_score} 컴퓨터"
 
     def make_initial_choice(self, choice):
+        # ----------------------------
+        # 플레이어도 같은 패 2번 선택 가능하도록 수정
+        # 버튼 비활성화 금지
+        # ----------------------------
         if len(self.player_choices) < 2:
             self.player_choices.append(choice)
-            self.buttons[choice].config(state=tk.DISABLED)
 
         if len(self.player_choices) == 1:
             self.info_label.config(text="두 번째 손을 선택하세요")
@@ -108,28 +129,39 @@ class RockPaperScissorsGUI:
             self.setup_final_choice_phase()
 
     def setup_final_choice_phase(self):
+        # 입력 버튼 비활성화
         for button in self.buttons.values():
             button.config(state=tk.DISABLED)
 
-        self.computer_choices = random.sample(list(self.options.keys()), 2)
+        # 컴퓨터 중복 선택 허용
+        self.computer_choices = random.choices(list(self.options.keys()), k=2)
+
         self.computer_hand1_label.config(text=self.computer_choices[0])
         self.computer_hand2_label.config(text=self.computer_choices[1])
-        
+
         self.info_label.config(text="컴퓨터의 패를 보고 남길 손을 고르세요!")
 
+        # 플레이어 두 패 모두 버튼으로 제공 (가위/가위도 2개 생성됨)
         for choice in self.player_choices:
             btn = tk.Button(
-                self.player_selection_frame, text=choice, font=self.default_font, width=8, height=2,
-                command=lambda c=choice: self.play_round(c)
+                self.player_selection_frame, text=choice, font=self.default_font,
+                width=8, height=2, command=lambda c=choice: self.play_round(c)
             )
             btn.pack(side=tk.LEFT, padx=5)
             self.final_choice_buttons.append(btn)
 
+    # ==============================================================
+
     def get_outcome(self, hand1_k, hand2_k):
         h1 = self.options[hand1_k]
         h2 = self.options[hand2_k]
-        if h1 == h2: return 0
-        if (h1 == 'rock' and h2 == 'scissors') or (h1 == 'scissors' and h2 == 'paper') or (h1 == 'paper' and h2 == 'rock'): return 1
+
+        if h1 == h2:
+            return 0
+        if (h1 == 'rock' and h2 == 'scissors') or \
+           (h1 == 'scissors' and h2 == 'paper') or \
+           (h1 == 'paper' and h2 == 'rock'):
+            return 1
         return -1
 
     def get_computer_ai_choice(self):
@@ -142,45 +174,74 @@ class RockPaperScissorsGUI:
         player_outcomes_vs_c2 = [self.get_outcome(p, c2) for p in p_choices]
         score_if_c2 = -max(player_outcomes_vs_c2)
 
-        if score_if_c1 > score_if_c2: return c1
-        if score_if_c2 > score_if_c1: return c2
+        if score_if_c1 > score_if_c2:
+            return c1
+        if score_if_c2 > score_if_c1:
+            return c2
         return random.choice([c1, c2])
+
+    # ==============================================================
 
     def show_win_popup(self):
         popup = tk.Toplevel(self.master)
         popup.title("승리!")
-        popup.geometry("250x280")
+        popup.geometry("260x300")
         popup.resizable(False, False)
-
-        try:
-            pokemon_id = random.randint(1, 898) # Gen 1 to 8
-            api_url = f"https://pokeapi.co/api/v2/pokemon/{pokemon_id}"
-            with urllib.request.urlopen(api_url) as response:
-                data = json.load(response)
-            
-            sprite_url = data['sprites']['front_default']
-            if not sprite_url: raise ValueError("Sprite URL not found")
-
-            with urllib.request.urlopen(sprite_url) as response:
-                image_data = response.read()
-            
-            base64_data = base64.b64encode(image_data)
-            self.pokemon_image = tk.PhotoImage(data=base64_data).zoom(2) # Make image bigger
-            
-            image_label = tk.Label(popup, image=self.pokemon_image)
-            image_label.pack(pady=10)
-
-        except Exception as e:
-            print(f"Pokemon API Error: {e}") # Log error for debugging
 
         win_label = tk.Label(popup, text="이겼어요!", font=self.info_font, fg="green")
         win_label.pack(pady=5)
-        
-        close_button = tk.Button(popup, text="닫기", command=popup.destroy, font=self.default_font)
+
+        image_label = tk.Label(popup)
+        image_label.pack(pady=10)
+
+        # 비동기로 포켓몬 이미지 로딩
+        threading.Thread(target=self.load_pokemon_async, args=(popup, image_label), daemon=True).start()
+
+        close_button = tk.Button(popup, text="닫기", command=popup.destroy,
+                                 font=self.default_font, padx=10, pady=5)
         close_button.pack(pady=10)
+
         popup.transient(self.master)
         popup.grab_set()
-        self.master.wait_window(popup)
+
+    # ==============================================================
+
+    def load_pokemon_async(self, popup, image_label):
+        """
+        스레드에서 포켓몬 데이터를 불러오고, UI 업데이트는 메인 스레드에서 safely 실행.
+        """
+
+        try:
+            pokemon_id = random.randint(1, 898)
+            api_url = f"https://pokeapi.co/api/v2/pokemon/{pokemon_id}"
+
+            with urllib.request.urlopen(api_url) as response:
+                data = json.load(response)
+
+            sprite_url = data['sprites']['front_default']
+            if not sprite_url:
+                raise ValueError("Sprite URL not found")
+
+            with urllib.request.urlopen(sprite_url) as response:
+                image_data = response.read()
+
+            # Pillow로 고품질 처리
+            pil_img = Image.open(io.BytesIO(image_data))
+            pil_img = pil_img.resize((150, 150), Image.LANCZOS)
+
+            tk_img = ImageTk.PhotoImage(pil_img)
+
+            self.master.after(0, lambda: self.update_popup_image(popup, image_label, tk_img))
+
+        except Exception as e:
+            print("Pokemon API Error:", e)
+
+    def update_popup_image(self, popup, image_label, tk_img):
+        self.pokemon_image = tk_img  # GC 방지
+        if popup.winfo_exists():  
+            image_label.config(image=self.pokemon_image)
+
+    # ==============================================================
 
     def play_round(self, player_final_choice_korean):
         for button in self.final_choice_buttons:
@@ -188,15 +249,29 @@ class RockPaperScissorsGUI:
 
         computer_final_choice_korean = self.get_computer_ai_choice()
         outcome = self.get_outcome(player_final_choice_korean, computer_final_choice_korean)
-        
+
         winner = 'draw'
         if outcome == 1:
             winner = 'player'
-            self.player_score += 1
+            self.player_score += 1  
+
+            # Critical Hit
+            if random.random() < self.critical_chance:
+                self.player_score += 1  
+                self.player_final_label.config(text=player_final_choice_korean, fg="blue")
+                self.computer_final_label.config(text=computer_final_choice_korean, fg="red")
+                self.vs_label.config(text="vs")
+                self.status_label.config(text="크리티컬 히트! +2점!", fg="purple")
+                self.score_label.config(text=self.get_score_text())
+                self.play_again_button.config(state=tk.NORMAL)
+                self.show_win_popup()
+                return
+
         elif outcome == -1:
             winner = 'computer'
             self.computer_score += 1
-        
+
+        # 기본 처리
         self.player_final_label.config(text=player_final_choice_korean, fg="blue")
         self.vs_label.config(text="vs")
         self.computer_final_label.config(text=computer_final_choice_korean, fg="red")
@@ -208,12 +283,14 @@ class RockPaperScissorsGUI:
         }
         message, color = status_messages[winner]
         self.status_label.config(text=message, fg=color)
-        
+
         self.score_label.config(text=self.get_score_text())
         self.play_again_button.config(state=tk.NORMAL)
 
         if winner == 'player':
             self.show_win_popup()
+
+    # ==============================================================
 
     def reset_game(self):
         self.player_choices = []
@@ -221,7 +298,7 @@ class RockPaperScissorsGUI:
         self.pokemon_image = None
 
         self.info_label.config(text="첫 번째 손을 선택하세요")
-        
+
         for button in self.buttons.values():
             button.config(state=tk.NORMAL)
 
@@ -238,6 +315,7 @@ class RockPaperScissorsGUI:
         self.status_label.config(text="")
 
         self.play_again_button.config(state=tk.DISABLED)
+
 
 if __name__ == "__main__":
     root = tk.Tk()


### PR DESCRIPTION
## 📝 Change Summary
### 1. 플레이어 전략 선택 로직 수정

기존: 첫 번째 버튼 선택 시 버튼이 비활성화되어 동일한 패를 2번 선택할 수 없었음

변경: 버튼 비활성화를 제거하여
→ 플레이어도 동일 패 2회 선택 가능(예: 가위-가위, 바위-바위)

효과: 게임 규칙이 실제 ‘하나빼기’ 전략과 일치

### 2. 컴퓨터 전략 선택 알고리즘 수정

기존: random.sample() 사용으로 중복 패 불가능

변경: random.choices(..., k=2) 적용

효과: 컴퓨터도 플레이어처럼 중복 전략 선택 가능

### 3. 최종 선택 UI 동작 수정

기존: 플레이어가 서로 다른 두 패를 선택한다고 가정

변경:

플레이어가 중복 선택한 경우에도
동일 버튼이 2개 생성되도록 UI 개선

효과: UI가 중복 전략을 정상적으로 반영

### 4. 포켓몬 이미지 품질 개선 (Pillow 적용)

기존: Tkinter PhotoImage zoom → 계단현상(픽셀 깨짐) 발생

변경:

Pillow로 이미지 로드

LANCZOS 리사이징 사용

효과: 고화질 이미지 렌더링으로 팝업 시각 품질 향상

### 5. 포켓몬 API 호출 비동기화

기존: urllib.request.urlopen을 메인 스레드에서 실행 → UI 프리즈

변경:

threading.Thread로 API I/O 분리

UI 업데이트는 master.after()로 메인 스레드에서 처리

효과: 포켓몬 로딩 중에도 게임 UI가 멈추지 않음

### 6. 승리 팝업 구조 개선

이미지 로딩 실패 대비 try-except 보강

팝업 UI 업데이트 함수 분리

self.pokemon_image 보관으로 GC 관련 이미지 손실 방지

### 7. 전체 코드 안정성 및 구조 개선

초기화 로직 정리

버튼/라벨 상태 초기화 명확화

함수 책임도를 분리하여 가독성 향상

일부 중복 코드 제거 및 흐름 개선

🎉 결과

플레이어/컴퓨터 모두 중복 전략이 가능한 완전한 ‘하나빼기’ RPS 게임 구현

포켓몬 팝업 이미지 품질 및 UI 응답성 크게 개선

전체적인 사용자 경험(UX) 향상